### PR TITLE
Add nullness check of CacheBuilder

### DIFF
--- a/src/heros/solver/IDESolver.java
+++ b/src/heros/solver/IDESolver.java
@@ -158,8 +158,10 @@ public class IDESolver<N,D,M,V,I extends InterproceduralCFG<N, M>> {
 	 */
 	public IDESolver(IDETabulationProblem<N,D,M,V,I> tabulationProblem, @SuppressWarnings("rawtypes") CacheBuilder flowFunctionCacheBuilder, @SuppressWarnings("rawtypes") CacheBuilder edgeFunctionCacheBuilder) {
 		if(logger.isDebugEnabled()) {
-			flowFunctionCacheBuilder = flowFunctionCacheBuilder.recordStats();
-			edgeFunctionCacheBuilder = edgeFunctionCacheBuilder.recordStats();
+			if(flowFunctionCacheBuilder != null)
+				flowFunctionCacheBuilder = flowFunctionCacheBuilder.recordStats();
+			if(edgeFunctionCacheBuilder != null)
+				edgeFunctionCacheBuilder = edgeFunctionCacheBuilder.recordStats();
 		}
 		this.zeroValue = tabulationProblem.zeroValue();
 		this.icfg = tabulationProblem.interproceduralCFG();		


### PR DESCRIPTION
Add a check of whether the CacheBuilder arguments are null so that we won't get NullPointerException when the solver is run in DEBUG mode without CacheBuilder.
