### PR TITLE
Update AllTop.java

### DIFF
--- a/src/heros/edgefunc/AllTop.java
+++ b/src/heros/edgefunc/AllTop.java
@@ -26,7 +26,7 @@ public class AllTop<V> implements EdgeFunction<V> {
 	}
 
 	public EdgeFunction<V> composeWith(EdgeFunction<V> secondFunction) {
-		return secondFunction;
+		return this;
 	}
 
 	public EdgeFunction<V> joinWith(EdgeFunction<V> otherFunction) {


### PR DESCRIPTION
AllTop composed with anything should be AllTop, right? 
Note that in the current implementation AllBottom composed with 'anything' yields 'anything'. The composition behavior of AllTop and AllBottom are therefore equal, which cannot be correct.