### PR TITLE
Use proper class to get logger from LoggerFactory.

### DIFF
--- a/src/heros/solver/CountingThreadPoolExecutor.java
+++ b/src/heros/solver/CountingThreadPoolExecutor.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
  */
 public class CountingThreadPoolExecutor extends ThreadPoolExecutor {
 	
-    protected static final Logger logger = LoggerFactory.getLogger(IDESolver.class);
+    protected static final Logger logger = LoggerFactory.getLogger(CountingThreadPoolExecutor.class);
 
     protected final CountLatch numRunningTasks = new CountLatch(0);
 	


### PR DESCRIPTION
This is just a fix for parameter of `LoggerFactory.getLogger()`.