### PR TITLE
Added ant target to publish heros jar files to local ivy repository.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<project name="heros" default="jar">
+<project xmlns:ivy="antlib:org.apache.ivy.ant" name="heros" default="jar">
     <property file="ant.settings"/>
+
+	<property name="ivy.install.version" value="2.1.0-rc2" />
+	<condition property="ivy.home" value="${env.IVY_HOME}">
+		<isset property="env.IVY_HOME" />
+	</condition>
+	<property name="ivy.home" value="${user.home}/.ivy2" />
+	<property name="ivy.jar.dir" value="${ivy.home}/lib" />
+	<property name="ivy.jar.file" value="${ivy.jar.dir}/ivy.jar" />
+
     <target name="settings">
         <fail
             message="Please copy ant.settings.template to ant.settings, and set the variables in it."
@@ -137,6 +146,39 @@
         <jar destfile="herossources-${heros.version}.jar">
             <fileset dir="src"/>
         </jar>
+	</target>
+
+
+	<!-- IVY RELATED TARGETS -->
+
+	<target name="download-ivy" unless="offline">
+
+		<mkdir dir="${ivy.jar.dir}"/>
+		<!-- download Ivy from web site so that it can be used even without any special installation -->
+		<get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.install.version}/ivy-${ivy.install.version}.jar"
+			 dest="${ivy.jar.file}" usetimestamp="true"/>
+	</target>
+
+	<target name="init-ivy" depends="download-ivy">
+		<!-- try to load ivy here from ivy home, in case the user has not already dropped
+                it into ant's lib dir (note that the latter copy will always take precedence).
+                We will not fail as long as local lib dir exists (it may be empty) and
+                ivy is in at least one of ant's lib dir or the local lib dir. -->
+		<path id="ivy.lib.path">
+			<fileset dir="${ivy.jar.dir}" includes="*.jar"/>
+
+		</path>
+		<taskdef resource="org/apache/ivy/ant/antlib.xml"
+				 uri="antlib:org.apache.ivy.ant" classpathref="ivy.lib.path"/>
+	</target>
+
+	<target name="publish-local" depends="init-ivy, jar, classesjar, sourcejar, javadoc">
+		<copy file="heros-${heros.version}.jar" tofile="herosjar-${heros.version}.jar" />
+		<copy file="herossources-${heros.version}.jar" tofile="herossource-${heros.version}.jar" />
+		<ivy:resolve/>
+		<ivy:publish pubrevision="${heros.version}" status="release" resolver="local" overwrite="true" >
+			<artifacts pattern="[artifact][type]-[revision].[ext]"/>
+		</ivy:publish>
 	</target>
 
 </project>

--- a/ivy.xml
+++ b/ivy.xml
@@ -1,0 +1,19 @@
+<ivy-module version="2.0">
+    <info organisation="ca.mcgill.sable" module="heros"/>
+    <publications>
+        <artifact name="heros" type="jar" ext="jar" />
+        <artifact name="heros" type="javadoc" ext="jar" />
+        <artifact name="heros" type="source" ext="jar" />
+        <!--
+        <artifact name="heros" type="classes" ext="jar" />
+        -->
+    </publications>
+    <!--<dependencies>
+        <dependency org="com.google.guava" name="guava" rev="18.0"/>
+        <dependency org="org.slf4j" name="slf4j-api" rev="1.7.5"/>
+        <dependency org="org.slf4j" name="slf4j-simple" rev="1.7.5"/>
+        <dependency org="org.mockito" name="mockito-all" rev="1.9.5"/>
+        <dependency org="org.hamcrest" name="hamcrest-core" rev="1.3"/>
+        <dependency org="junit" name="junit" rev="4.12"/>
+    </dependencies>-->
+</ivy-module>


### PR DESCRIPTION
Added ant target to publish heros jar files to local ivy repository.
If there is no ivy-plugin for ant installed, the ant script loads ivy.jar from maven-repo and packs it into the ant directory.

It would be easy to manage the dependencies (guava, self, mockito, hamcrest and junit) also via ivy.
Furthermore it would be comfortable to also publish heros to a public maven repository (maven central and/or a snapshot repo)