### PR TITLE
Allows the programmer to hook into value computation

### DIFF
--- a/src/heros/solver/IDESolver.java
+++ b/src/heros/solver/IDESolver.java
@@ -746,10 +746,14 @@ public class IDESolver<N,D,M,V,I extends InterproceduralCFG<N, M>> {
 		}
 	}
 	
+	protected V joinValueAt(N unit, D fact, V curr, V newVal) {
+		return valueLattice.join(curr, newVal);
+	}
+	
 	private void propagateValue(N nHashN, D nHashD, V v) {
 		synchronized (val) {
 			V valNHash = val(nHashN, nHashD);
-			V vPrime = valueLattice.join(valNHash,v);
+			V vPrime = joinValueAt(nHashN, nHashD, valNHash,v);
 			if(!vPrime.equals(valNHash)) {
 				setVal(nHashN, nHashD, vPrime);
 				scheduleValueProcessing(new ValuePropagationTask(new Pair<N,D>(nHashN,nHashD)));


### PR DESCRIPTION
Adds a new method, joinValueAt which allows the programmer to
hook into the value computation phase. The goal here is not to
change how values are computed (it is wholly expected that the
valueLattice will be used) but to allow the programmer to identify
unit/fact pairs of interest during the value computation phase.

That said, if there is a better way using existing IDESolver functionality to compute unit/facts/values of interest after the fact I would be happy to moot the PR.