### PR TITLE
Modified POM to use new Maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,7 @@
   </properties>
   
   <build>
+ <finalName>herosclasses-trunk</finalName>
     <sourceDirectory>src</sourceDirectory>
     <testSourceDirectory>test</testSourceDirectory>
     <resources>
@@ -22,6 +23,30 @@
         </excludes>
       </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    <plugin>
+      <artifactId>maven-assembly-plugin</artifactId>
+      <configuration>
+      	<finalName>heros-trunk</finalName>
+      	<appendAssemblyId>false</appendAssemblyId>        
+      	<descriptorRefs>
+          <descriptorRef>jar-with-dependencies</descriptorRef>
+        </descriptorRefs>
+      </configuration>
+    </plugin>
+    </plugins>
   </build>
   <dependencies>
     <dependency>


### PR DESCRIPTION
jar with all dependencies can be build with „mvn assembly:single“