### PR TITLE
Fix NPE when generating dot graph for a unit that contains no facts

### DIFF
--- a/src/heros/solver/FlowFunctionDotExport.java
+++ b/src/heros/solver/FlowFunctionDotExport.java
@@ -181,8 +181,10 @@ public class FlowFunctionDotExport<N,D,M,I extends InterproceduralCFG<N, M>> {
 			Set<D> loc = utf.factsForUnit.get(methodUnit);
 			String unitText = escapeLabelString(printer.printNode(methodUnit, method));
 			pf.print(utf.getUnitLabel(methodUnit) + " [shape=record,label=\""+ unitText + " ");
-			for(D hl : loc) {
-				pf.print("| <" + utf.getFactLabel(methodUnit, hl) + "> " + escapeLabelString(printer.printFact(hl)));
+			if(loc != null){//NOTE: if the '0' fact is removed for some reason this will be null
+				for(D hl : loc) {
+					pf.print("| <" + utf.getFactLabel(methodUnit, hl) + "> " + escapeLabelString(printer.printFact(hl)));
+				}
 			}
 			pf.println("\"];");
 		}


### PR DESCRIPTION
If a Unit contains no facts (i.e. even the '0' fact is killed, not generated, etc.), then the dot graph export would fail with a NullPointerException. The fix simply adds a null check so that the graph will be generated successfully with the aforementioned Unit containing no facts, as expected.